### PR TITLE
Revert to default indentation when pressing ENTER directly after "("

### DIFF
--- a/indent_to_parenthesis.py
+++ b/indent_to_parenthesis.py
@@ -12,7 +12,7 @@ class IndentToParenthesisCommand(sublime_plugin.TextCommand):
       param_column = self.find_last_unmatched_open_paren(line_upto_cursor)
       whitespace_region = self.expand_to_whitespace(selection.a)
       view.erase(edit, whitespace_region)
-      if param_column:
+      if param_column and not line_upto_cursor.rstrip().endswith('('):
         view.insert(edit, whitespace_region.a, '\n%s' % (' ' * param_column))
       else:
         view.run_command('insert', {'characters': '\n'})


### PR DESCRIPTION
Currently the behaviour is:
```
run_test_function(arg1,<ENTER>
                  # Indents here: good!

run_test_function(<ENTER>
                  # Indents here: bad!
```

But that doesn't really make much sense as you wouldn't press ENTER in that case.

With `indent_to_bracket` set to `false` (the default) the new behaviour is:
```
run_test_function(arg1,<ENTER>
                  # Indents here: good!

run_test_function(<ENTER>
    # Indents here: good!
```

If people explicitly want to indent to the parenthesis even after a "(", they can still set `indent_to_bracket` to `true`